### PR TITLE
Fixed Firefox compatibility - removed toReversed()

### DIFF
--- a/practice/archi/mmu/va_fields.inc
+++ b/practice/archi/mmu/va_fields.inc
@@ -121,7 +121,7 @@ if (document.getElementById("vpFields") != null ||
         מבנה השדה דף וירטואלי הוא מבנה
         כתובת וירטואלית ללא שדה ההיסט,
         כלומר
-        (${a.toReversed().slice(0,-1).join(",")}).
+        (${[...a].reverse().slice(0,-1).join(",")}).
     </li>`;
 }
 
@@ -139,11 +139,11 @@ explanation += "</ol>";
 function showAnswer() {
     let e = document.getElementById("vaFields");
     if (e != null)
-        e.innerHTML = `(${a.toReversed().join(",")})`; 
+        e.innerHTML = `(${[...a].reverse().join(",")})`; 
 
     e = document.getElementById("vpFields");
     if (e != null) {
-        e.innerHTML = `(${a.toReversed().slice(0,-1).join(",")})`;
+        e.innerHTML = `(${[...a].reverse().slice(0,-1).join(",")})`;
     }
 
     e = document.getElementById("tblHeight");


### PR DESCRIPTION
As per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed) `toReversed()` is not supported in Firefox and some questions were not working since this function was used.

I replaced `a.toReversed()` with `[...a].reverse()` which dose the same copy and reverse as `toReversed()` and is [supported ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reverse) on all modern browses.